### PR TITLE
feat(server): POST /api/v1/rooms — E1 in-memory rooms

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -18,6 +18,14 @@
 
 - **Dynamic** `import('phaser')` в коде, который грузится **только** при входе на маршрут арены. См. [ADR 0003](adr/0003-client-rendering-phaser.md).
 
+## HTTP (создание комнаты)
+
+- **`POST /api/v1/rooms`** — создать room в памяти; тело запроса пустое (v0.1). Ответ **201** JSON:
+  - `roomId` — внутренний идентификатор;
+  - `inviteCode` — ключ для path (`/g/{inviteCode}`);
+  - `createdAt` — RFC3339Nano (UTC);
+  - `paths` — `{ "g": "/g/{inviteCode}", "join": "/join/{inviteCode}" }` для копирования на клиенте.
+
 ## WebSocket (детализация по мере кода)
 
 - Подключение, когда заданы `inviteCode` из path, **displayName** с арены, при необходимости id сессии — типы в `server/`.  

--- a/server/internal/room/store.go
+++ b/server/internal/room/store.go
@@ -1,0 +1,72 @@
+package room
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"sync"
+	"time"
+)
+
+const inviteCodeBytes = 9 // url-safe base64 without padding → 12 chars
+
+// Room is an in-memory session container for v0.1 (no persistence).
+type Room struct {
+	ID         string    `json:"id"`
+	InviteCode string    `json:"inviteCode"`
+	CreatedAt  time.Time `json:"createdAt"`
+}
+
+// Store holds rooms keyed by invite code (single source for lookup).
+type Store struct {
+	mu     sync.RWMutex
+	byCode map[string]*Room
+}
+
+// NewStore returns an empty in-memory room store.
+func NewStore() *Store {
+	return &Store{byCode: make(map[string]*Room)}
+}
+
+// Create allocates a new room with a unique invite code.
+func (s *Store) Create() (*Room, error) {
+	const maxAttempts = 16
+	for i := 0; i < maxAttempts; i++ {
+		code, err := randomInviteCode()
+		if err != nil {
+			return nil, err
+		}
+		s.mu.Lock()
+		if _, exists := s.byCode[code]; exists {
+			s.mu.Unlock()
+			continue
+		}
+		r := &Room{
+			ID:         newRoomID(),
+			InviteCode: code,
+			CreatedAt:  time.Now().UTC(),
+		}
+		s.byCode[code] = r
+		s.mu.Unlock()
+		return r, nil
+	}
+	return nil, errors.New("room: could not allocate unique invite code")
+}
+
+func randomInviteCode() (string, error) {
+	b := make([]byte, inviteCodeBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	// URL-safe, no padding — allowed in path per PROTOCOL (/g/{inviteCode}).
+	s := base64.RawURLEncoding.EncodeToString(b)
+	return s, nil
+}
+
+func newRoomID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("room: crypto/rand failed: " + err.Error())
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/server/internal/room/store_test.go
+++ b/server/internal/room/store_test.go
@@ -1,0 +1,46 @@
+package room
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestStoreCreateUniqueCodes(t *testing.T) {
+	s := NewStore()
+	seen := make(map[string]struct{})
+	const n = 100
+	for i := 0; i < n; i++ {
+		r, err := s.Create()
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if r.InviteCode == "" {
+			t.Fatal("empty invite code")
+		}
+		if _, dup := seen[r.InviteCode]; dup {
+			t.Fatalf("duplicate invite code %q", r.InviteCode)
+		}
+		seen[r.InviteCode] = struct{}{}
+	}
+}
+
+func TestStoreCreateConcurrent(t *testing.T) {
+	s := NewStore()
+	var wg sync.WaitGroup
+	errs := make(chan error, 50)
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := s.Create()
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent Create: %v", err)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"embed"
+	"encoding/json"
 	"io"
 	"io/fs"
 	"log"
@@ -9,6 +10,9 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
+
+	"rpg-retro/server/internal/room"
 )
 
 //go:embed all:web/dist
@@ -16,11 +20,35 @@ var static embed.FS
 
 func main() {
 	mux := http.NewServeMux()
+	rooms := room.NewStore()
 
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok\n")
+	})
+
+	mux.HandleFunc("POST /api/v1/rooms", func(w http.ResponseWriter, r *http.Request) {
+		created, err := rooms.Create()
+		if err != nil {
+			log.Printf("create room: %v", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		resp := createRoomResponse{
+			RoomID:     created.ID,
+			InviteCode: created.InviteCode,
+			CreatedAt:  created.CreatedAt.Format(time.RFC3339Nano),
+			Paths: roomPaths{
+				G:    "/g/" + created.InviteCode,
+				Join: "/join/" + created.InviteCode,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			log.Printf("encode create room: %v", err)
+		}
 	})
 
 	fsys, err := fs.Sub(static, "web/dist")
@@ -38,6 +66,18 @@ func main() {
 	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatal(err)
 	}
+}
+
+type createRoomResponse struct {
+	RoomID     string    `json:"roomId"`
+	InviteCode string    `json:"inviteCode"`
+	CreatedAt  string    `json:"createdAt"`
+	Paths      roomPaths `json:"paths"`
+}
+
+type roomPaths struct {
+	G    string `json:"g"`
+	Join string `json:"join"`
 }
 
 type spaFileServer struct{ fsys fs.FS }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **MVP epic E1**: create room via HTTP, in-memory `Room` model with **invite code**, plus brief **PROTOCOL.md** contract for the endpoint.

## Changes

- **`POST /api/v1/rooms`** — empty body; **201** JSON with `roomId`, `inviteCode`, `createdAt` (RFC3339Nano UTC), and `paths.g` / `paths.join` for SPA deep links (`/g/{code}`, `/join/{code}`).
- **`internal/room`** — thread-safe store; invite codes are **URL-safe** base64 (no padding), suitable for path segments per [PROTOCOL](docs/PROTOCOL.md).
- **Tests** — uniqueness and concurrent creation on the store.

## Verification

- `go test ./...` under `server/`
- Manual smoke: `go build` + `curl -X POST .../api/v1/rooms`

Docker build was not run (Docker CLI unavailable in this environment).

## Next

**E2**: SPA routing (`/`, `/g/*`, `/join/*`), client history router, lazy Phaser on arena route.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69f58852-b96b-409c-b3c8-ca0771c1b952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69f58852-b96b-409c-b3c8-ca0771c1b952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

